### PR TITLE
Directory build updates

### DIFF
--- a/templates/buildprops/.template.config/template.json
+++ b/templates/buildprops/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Shaun Smith",
   "classifications": [
-    "Config"
+    "Common", "Console", "Library"
   ],
   "identity": "bitcrafter.buildprops",
   "name": "BuildPropsTemplate",
@@ -29,15 +29,26 @@
       },
       "replaces": "1999"
     },
-    "author": {
+    "authors": {
       "type": "parameter",
+      "datatype": "string",
       "defaultValue": "John Doe",
-      "replaces": "John Doe"
+      "replaces": "John Doe",
+      "description": "Sets the 'Authors' assembly metadata for all projects in the solution, used to identify the authors of the project."
     },
     "company": {
+      "binding": "",
       "type": "parameter",
+      "datatype": "string",
       "defaultValue": "Acme Inc",
-      "replaces": "Acme Inc"
+      "replaces": "Acme Inc",
+      "description": "Sets the 'Company' assembly metadata for all projects in the solution, used to identify the company that produced the project."
+    },
+    "treatWarningsAsErrors": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "When true, build warnings are treated as errors."
     }
   }
 }

--- a/templates/buildprops/Directory.Build.props
+++ b/templates/buildprops/Directory.Build.props
@@ -1,17 +1,15 @@
 <Project>
   <PropertyGroup>
-    <!-- Prevents non-SDK projects from re-importing -->
-    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-
     <!-- Configure code analysis -->
     <!-- This is enabled by default in NET5+ -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-
-    <!-- Force warnings to be dealt with -->
-    <!--<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>-->
+    <!--#if (treatWarningsAsErrors) -->
+    <!-- Treat warning as errors -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+    <!--#endif -->
   </PropertyGroup>
 
   <!-- Configure generic assembly information -->
@@ -36,19 +34,23 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="FluentAssertions" Version="6.11.0"/>
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.19.1">
+    <PackageReference Include="FluentAssertions" Version="6.12.0"/>
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.32.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
-    <PackageReference Include="Moq" Version="4.18.4"/>
-    <PackageReference Include="xunit" Version="2.4.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
+    <PackageReference Include="Moq" Version="4.20.70"/>
+    <PackageReference Include="xunit" Version="2.8.1"/>
+    <PackageReference Include="xunit.analyzers" Version="1.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/templates/buildprops/Directory.Build.props
+++ b/templates/buildprops/Directory.Build.props
@@ -24,18 +24,18 @@
 
   <!-- Project Conventions -->
   <PropertyGroup>
-    <!-- Sets IsUnitTestProject to true if our project followings the convention where unit test project names end in 'Test' or 'Tests' -->
-    <IsUnitTestProject Condition=" '$(IsUnitTestProject)' == '' AND ( $(MSBuildProjectName.EndsWith('.Test')) OR $(MSBuildProjectName.EndsWith('.Tests')) ) ">true</IsUnitTestProject>
-    <IsUnitTestProject Condition=" '$(IsUnitTestProject)' == '' ">false</IsUnitTestProject>
+    <!-- Sets IsTestProject to true if our project followings the convention where unit test project names end in 'Test' or 'Tests' -->
+    <IsTestProject Condition=" '$(IsTestProject)' == '' AND ( $(MSBuildProjectName.EndsWith('.Test')) OR $(MSBuildProjectName.EndsWith('.Tests')) ) ">true</IsTestProject>
+    <IsTestProject Condition=" '$(IsTestProject)' == '' ">false</IsTestProject>
   </PropertyGroup>
 
   <!-- Configure Unit Test Projects -->
   <!-- These properties/references can be removed by default, or overriden with a different version/value if desired -->
-  <PropertyGroup Condition="'$(IsUnitTestProject)' == 'true'">
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsUnitTestProject)' == 'true'">
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <PackageReference Include="FluentAssertions" Version="6.11.0"/>
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.19.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Removes `ImportDirectoryBuildProps`
Switch `IsUnitTestProject` to `IsTestProject` to align with net7+ project template variable.
Allows toggling of `TreatWarningsAsErrors` by template parameter.
Update referenced packages